### PR TITLE
Add YouTube / YouTube Music playlist import

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1252,6 +1252,32 @@ ipcMain.handle('spotify:matchTrack', async (_event, title, artist) => {
   }
 });
 
+// ─── YouTube Music Playlist Import ───
+
+ipcMain.handle('yt:getPlaylistVideos', async (_event, playlistId) => {
+  try {
+    const playlist = await ytmusic.getPlaylist(playlistId);
+    const videos = await ytmusic.getPlaylistVideos(playlistId);
+    const tracks = videos
+      .filter(v => v.videoId)
+      .map(v => ({
+        id: v.videoId,
+        title: v.name || 'Unknown',
+        artist: v.artist?.name || 'Unknown Artist',
+        artistId: v.artist?.artistId || null,
+        album: null,
+        thumbnail: getSquareThumbnail(v.thumbnails),
+        duration: formatDuration(v.duration),
+        durationMs: v.duration ? Math.round(v.duration * 1000) : 0,
+        url: `https://music.youtube.com/watch?v=${v.videoId}`
+      }));
+    return { name: playlist.name, videoCount: playlist.videoCount, tracks };
+  } catch (err) {
+    console.error('YT playlist fetch error:', err);
+    return { error: err.message };
+  }
+});
+
 // ─── Playlist Cover Image Management ───
 
 function getCoversDir() {

--- a/src/preload.js
+++ b/src/preload.js
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld('snowify', {
   charts: () => ipcRenderer.invoke('yt:charts'),
   browseMood: (browseId, params) => ipcRenderer.invoke('yt:browseMood', browseId, params),
   setCountry: (code) => ipcRenderer.invoke('yt:setCountry', code),
+  getPlaylistVideos: (playlistId) => ipcRenderer.invoke('yt:getPlaylistVideos', playlistId),
   getLyrics: (trackName, artistName, albumName, duration) => ipcRenderer.invoke('lyrics:get', trackName, artistName, albumName, duration),
   openExternal: (url) => ipcRenderer.invoke('shell:openExternal', url),
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -82,6 +82,11 @@
         <div class="sidebar-section-header">
           <h3>Playlists</h3>
           <div class="sidebar-header-actions">
+            <button class="icon-btn" id="btn-ytmusic-import" title="Import from YouTube / YouTube Music">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0C5.376 0 0 5.376 0 12s5.376 12 12 12 12-5.376 12-12S18.624 0 12 0zm0 19.104c-3.924 0-7.104-3.18-7.104-7.104S8.076 4.896 12 4.896s7.104 3.18 7.104 7.104-3.18 7.104-7.104 7.104zm0-13.332c-3.432 0-6.228 2.796-6.228 6.228S8.568 18.228 12 18.228s6.228-2.796 6.228-6.228S15.432 5.772 12 5.772zM9.684 15.54V8.46L15.816 12l-6.132 3.54z"/>
+              </svg>
+            </button>
             <button class="icon-btn" id="btn-spotify-import" title="Import from Spotify">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm5.52 17.28c-.24.36-.66.48-1.02.24-2.82-1.74-6.36-2.1-10.56-1.14-.42.12-.78-.18-.9-.54-.12-.42.18-.78.54-.9 4.56-1.02 8.52-.6 11.7 1.32.36.24.48.66.24 1.02zm1.44-3.3c-.3.42-.84.6-1.26.3-3.24-1.98-8.16-2.58-11.94-1.38-.48.12-.99-.12-1.14-.6-.12-.48.12-.99.6-1.14 4.38-1.32 9.78-.66 13.5 1.62.36.18.54.78.24 1.2zm.12-3.36C15.24 8.4 8.88 8.16 5.16 9.3c-.6.18-1.2-.18-1.38-.72-.18-.6.18-1.2.72-1.38 4.26-1.26 11.28-1.02 15.72 1.62.54.3.72 1.02.42 1.56-.3.42-1.02.6-1.56.3z"/></svg>
             </button>
@@ -658,6 +663,35 @@
         <div class="spotify-track-list" id="spotify-track-list"></div>
         <div class="modal-buttons" id="spotify-done-buttons" style="display:none">
           <button class="modal-btn modal-confirm" id="spotify-done">Done</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ═══════ YouTube Music Import Modal ═══════ -->
+  <div id="ytmusic-modal" class="modal-overlay hidden">
+    <div class="modal-box spotify-modal-box">
+      <h3 id="ytmusic-modal-title">Import YouTube Playlists</h3>
+      <div id="ytmusic-step-url" class="spotify-step">
+        <p class="spotify-step-desc">Paste one or more YouTube or YouTube Music playlist URLs, one per line.</p>
+        <textarea id="ytmusic-url-input" class="ytmusic-textarea" rows="4" placeholder="https://youtube.com/playlist?list=...&#10;https://music.youtube.com/playlist?list=..." spellcheck="false"></textarea>
+        <p class="spotify-error hidden" id="ytmusic-error"></p>
+        <div class="modal-buttons">
+          <button class="modal-btn modal-cancel" id="ytmusic-cancel">Cancel</button>
+          <button class="modal-btn modal-confirm" id="ytmusic-start" disabled>Import</button>
+        </div>
+      </div>
+      <div id="ytmusic-step-progress" class="spotify-step hidden">
+        <div class="spotify-progress-info">
+          <span id="ytmusic-progress-text">Fetching playlist...</span>
+          <span id="ytmusic-progress-count"></span>
+        </div>
+        <div class="spotify-progress-bar">
+          <div class="spotify-progress-fill" id="ytmusic-progress-fill"></div>
+        </div>
+        <div class="spotify-track-list" id="ytmusic-track-list"></div>
+        <div class="modal-buttons" id="ytmusic-done-buttons" style="display:none">
+          <button class="modal-btn modal-confirm" id="ytmusic-done">Done</button>
         </div>
       </div>
     </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2767,6 +2767,34 @@ html, body {
   background: rgba(0, 0, 0, 0.08);
 }
 
+
+/* ═══════ YouTube Music Import ═══════ */
+.ytmusic-textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  resize: vertical;
+  outline: none;
+  transition: border-color var(--transition);
+  margin-bottom: 12px;
+}
+.ytmusic-textarea:focus {
+  border-color: var(--accent);
+}
+.ytmusic-textarea::placeholder {
+  color: var(--text-subdued);
+}
+[data-theme="light"] .ytmusic-textarea {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+
 /* ── Drag & Drop ── */
 .track-row[draggable="true"],
 .track-card[draggable="true"] {


### PR DESCRIPTION
## Summary
  - New sidebar button (YouTube icon) to import playlists by pasting YouTube or YouTube Music URLs
  - Supports importing multiple playlists at once (one URL per line) with progress tracking
  - Uses existing `ytmusic-api` library via a new `yt:getPlaylistVideos` IPC handler in main process
  - Detects and rejects auto-generated playlists (radio/mixes with `RD` or `OLAK5uy_` prefixes) with a friendly error message
  - Reuses the Spotify import modal design (progress bar, track list, done state) for visual consistency
  - Adds `.ytmusic-textarea` styles with light/dark theme support for the URL input

  ## Screenshots

  | Sidebar button | Import modal | Imported playlist |
  |:-:|:-:|:-:|
  | ![button](https://github.com/user-attachments/assets/fbf9b22d-cc5c-4118-a689-486ae077c24e) | ![modal](https://github.com/user-attachments/assets/58d13dbf-6e8b-4630-8d2f-ebd76837b24d) |
  ![imported](https://github.com/user-attachments/assets/81c4d121-56c9-439d-9023-610a2453bbcf) |
