### PR TITLE
Add clickable track title to navigate to album detail

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -152,6 +152,7 @@ function mapSongToTrack(song, artists) {
     title: song.name || 'Unknown',
     ...artistFields,
     album: song.album?.name || null,
+    albumId: song.album?.albumId || null,
     thumbnail: getSquareThumbnail(song.thumbnails),
     duration: formatDuration(song.duration),
     durationMs: song.duration ? Math.round(song.duration * 1000) : 0,

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -889,7 +889,15 @@
     document.querySelector('#app').classList.remove('no-player');
 
     $('#np-thumbnail').src = track.thumbnail;
-    $('#np-title').textContent = track.title;
+    const npTitle = $('#np-title');
+    npTitle.textContent = track.title;
+    if (track.albumId) {
+      npTitle.classList.add('clickable');
+      npTitle.onclick = () => showAlbumDetail(track.albumId, { name: track.album, thumbnail: track.thumbnail });
+    } else {
+      npTitle.classList.remove('clickable');
+      npTitle.onclick = null;
+    }
 
     const npArtist = $('#np-artist');
     npArtist.innerHTML = renderArtistLinks(track);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1076,6 +1076,12 @@ html, body {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.np-title.clickable {
+  cursor: pointer;
+}
+.np-title.clickable:hover {
+  text-decoration: underline;
+}
 .np-artist {
   font-size: 12px;
   color: var(--text-subdued);


### PR DESCRIPTION
  ## Summary
  - Adds `albumId` to track objects from `mapSongToTrack()`
  - Makes the track title in the now playing bar clickable — navigates to the album detail view
  - Conditional: only clickable when the track has an album (videos/remixes without album stay as plain text)

  ## Test plan
  - [ ] Play a song that belongs to an album → hover title shows underline, click opens album detail
  - [ ] Play a video/remix without album → title is plain text, no hover effect
  - [ ] Artist links in now playing bar still work independently
  - [ ] No regressions in search results, playlists, or queue


https://github.com/user-attachments/assets/a874ecf5-f96c-47fe-bd55-fffd86bb1fe6

