### PR TITLE
Show floating search bar on artist and album views

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -156,7 +156,7 @@
   floatingSearch.addEventListener('click', () => switchView('search'));
 
   function updateFloatingSearch() {
-    const show = ['home', 'explore', 'library', 'artist', 'album'].includes(state.currentView);
+    const show = ['home', 'explore', 'library', 'artist', 'album', 'playlist'].includes(state.currentView);
     floatingSearch.classList.toggle('hidden', !show);
   }
 


### PR DESCRIPTION
  ## Summary
  - The floating search bar was only visible on home, explore, and library views
  - Now also visible on artist and album views, so users can quickly search without navigating back

  ## Test plan
  - [ ] Open an artist page → floating search bar is visible
  - [ ] Open an album page → floating search bar is visible