### PR TITLE
Moved scroll arrows in explore to be on left / right of songs

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3446,7 +3446,7 @@ html, body {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  z-index: 2;
+  z-index: 10;
   width: 32px;
   height: 32px;
   border: none;
@@ -3457,7 +3457,6 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 1;
   padding: 0;
   box-shadow: 0 2px 8px rgba(0,0,0,0.4);
 }
@@ -3465,10 +3464,10 @@ html, body {
   background: var(--bg-highlight);
 }
 .scroll-arrow-left {
-  left: 4px;
+  left: -34px;
 }
 .scroll-arrow-right {
-  right: 4px;
+  right: -34px;
 }
 
 /* ═══════ Top Artists (Horizontal Scroll) ═══════ */


### PR DESCRIPTION
Before:
<img width="1170" height="259" alt="image" src="https://github.com/user-attachments/assets/4746bd67-41d9-4dd5-8186-ce32268eabf3" />

After:
<img width="1211" height="273" alt="image" src="https://github.com/user-attachments/assets/26dcd257-fa89-4b4f-8851-8e1a263af0c1" />

Made it so the scroll arrows are on the left and right of the songs in the explore menu.
