### PR TITLE
Made lyrics icon a Mic instead of a Note

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -614,7 +614,11 @@
 
     <div class="np-extras">
       <button class="icon-btn" id="btn-lyrics" title="Lyrics">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"></path>
+          <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+          <line x1="12" x2="12" y1="19" y2="22"></line>
+        </svg>
       </button>
       <button class="icon-btn" id="btn-queue" title="Queue">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h10v2H4v-2zm14-1v6l5-3-5-3z"/></svg>


### PR DESCRIPTION
Made the lyrics icon a microphone rather than a musical note as in my opinion a mic better represents lyrics than a musical note. This also more closely aligns it to Spotify making it a bit of an easier transition as I was confused when tried to find it then I realized the lyrics icon was a note.

Before:
<img width="59" height="56" alt="image" src="https://github.com/user-attachments/assets/ce6bc350-c4dc-417b-9e07-782fe29de4a4" />

After:
<img width="53" height="44" alt="image" src="https://github.com/user-attachments/assets/b2a37590-5fb4-493a-adcb-e02bdea93a96" />
