### PR TITLE
Fixed crossfade not working when Snowify is minimized

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ const os = require('os');
 const { execFile } = require('child_process');
 const { autoUpdater } = require('electron-updater');
 
+app.commandLine.appendSwitch('disable-renderer-backgrounding');
+
 let mainWindow;
 let ytmusic;
 let _currentCountry = '';
@@ -226,7 +228,8 @@ function createWindow() {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: false,
+      backgroundThrottling: false
     },
     icon: nativeImage.createFromPath(path.join(__dirname, '..', 'assets', 'logo.ico'))
   });


### PR DESCRIPTION
Basically when Snowify is minimized crossfade doesn't work and it keeps "playing" the song but just doesn't play audio and keeps running it, so when you open it back up, it may be halfway through without you hearing anything. I fixed this by adding just two lines of code preventing throttling and deprioritizing of the renderer process when the app is minimized. I tested it without and with the fix I applied on the latest source code and it does indeed fix the issue properly.