### PR TITLE
Add Ctrl+K keyboard shortcut for search bar focus

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -242,6 +242,7 @@
       renderExplore();
     }
     if (name === 'search') {
+      syncSearchHint();
       setTimeout(() => $('#search-input').focus(), 100);
     }
     if (name === 'library') {
@@ -258,6 +259,17 @@
   // ── Floating search pill ──
   const floatingSearch = $('#floating-search');
   floatingSearch.addEventListener('click', () => switchView('search'));
+
+  // ── Search shortcut hint (Ctrl+K / ⌘K) ──
+  const isMac = navigator.platform.includes('Mac');
+  const searchShortcutHint = $('#search-shortcut-hint');
+  const searchShortcutMod = $('#search-shortcut-mod');
+  const floatingSearchMod = $('#floating-search-mod');
+  if (searchShortcutMod) searchShortcutMod.textContent = isMac ? '⌘' : 'Ctrl';
+  if (floatingSearchMod) floatingSearchMod.textContent = isMac ? '⌘' : 'Ctrl';
+  function syncSearchHint() {
+    if (searchShortcutHint) searchShortcutHint.classList.toggle('hidden', !!searchInput.value.trim());
+  }
 
   function updateFloatingSearch() {
     const show = ['home', 'explore', 'library', 'artist', 'album', 'playlist'].includes(state.currentView);
@@ -350,6 +362,11 @@
         ${item.type === 'history' ? `<button class="search-suggestion-delete" data-query="${escapeHtml(item.text)}" title="Remove">${ICON_TRASH}</button>` : ''}
       </div>`;
     }).join('');
+    searchSuggestions.insertAdjacentHTML('beforeend',
+      '<div class="suggestions-hint-bar">' +
+        '<span class="suggestions-hint"><kbd>↑</kbd><kbd>↓</kbd> Navigate</span>' +
+        '<span class="suggestions-hint"><kbd>Enter</kbd> Search</span>' +
+      '</div>');
     searchSuggestions.classList.remove('hidden');
 
     // Bind clickable artist links inside song suggestions
@@ -360,6 +377,7 @@
         if (q) addToSearchHistory(q);
         searchInput.value = '';
         searchClear.classList.add('hidden');
+        syncSearchHint();
         closeSuggestions();
       });
     });
@@ -374,6 +392,7 @@
           if (q) addToSearchHistory(q);
           searchInput.value = '';
           searchClear.classList.add('hidden');
+          syncSearchHint();
           closeSuggestions();
           openArtistPage(el.dataset.artistId);
         } else if (type === 'album') {
@@ -382,6 +401,7 @@
           if (q) addToSearchHistory(q);
           searchInput.value = '';
           searchClear.classList.add('hidden');
+          syncSearchHint();
           closeSuggestions();
           showAlbumDetail(el.dataset.albumId, albumItem ? { name: albumItem.name, thumbnail: albumItem.thumbnail } : null);
         } else if (type === 'song') {
@@ -391,6 +411,7 @@
             if (q) addToSearchHistory(q);
             searchInput.value = '';
             searchClear.classList.add('hidden');
+            syncSearchHint();
             closeSuggestions();
             playFromList([songItem], 0);
           }
@@ -398,6 +419,7 @@
           const text = el.dataset.text;
           searchInput.value = text;
           searchClear.classList.toggle('hidden', !text);
+          syncSearchHint();
           closeSuggestions();
           addToSearchHistory(text);
           performSearch(text);
@@ -463,6 +485,7 @@
   searchInput.addEventListener('input', () => {
     const q = searchInput.value.trim();
     searchClear.classList.toggle('hidden', !q);
+    syncSearchHint();
     clearTimeout(searchTimeout);
     clearTimeout(suggestionsTimeout);
     if (!q) {
@@ -500,6 +523,7 @@
           const text = el.dataset.text;
           searchInput.value = text;
           searchClear.classList.toggle('hidden', !text);
+          syncSearchHint();
           closeSuggestions();
           addToSearchHistory(text);
           performSearch(text);
@@ -528,6 +552,7 @@
   searchClear.addEventListener('click', () => {
     searchInput.value = '';
     searchClear.classList.add('hidden');
+    syncSearchHint();
     renderSearchEmpty();
     closeSuggestions();
     searchInput.focus();
@@ -3149,6 +3174,16 @@
   }
 
   document.addEventListener('keydown', (e) => {
+    // Ctrl+K / Cmd+K — focus search (works even from inputs)
+    if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      searchInput.value = '';
+      searchClear.classList.add('hidden');
+      closeSuggestions();
+      switchView('search');
+      return;
+    }
+
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
       if (e.key === 'Escape') e.target.blur();
       return;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -110,6 +110,10 @@
       <div id="floating-search" class="floating-search">
         <svg class="floating-search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="11" cy="11" r="7"/><path d="M16 16l4.5 4.5" stroke-linecap="round"/></svg>
         <span class="floating-search-text">Search</span>
+        <div class="floating-search-keys" id="floating-search-keys">
+          <kbd id="floating-search-mod"></kbd>
+          <kbd>K</kbd>
+        </div>
       </div>
 
       <!-- ── Home View ── -->
@@ -155,6 +159,10 @@
           <div class="search-input-wrap">
             <svg class="search-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M16 16l4.5 4.5" stroke-linecap="round"/></svg>
             <input type="text" id="search-input" placeholder="What do you want to listen to?" spellcheck="false" autocomplete="off" />
+            <div class="search-shortcut-hint" id="search-shortcut-hint">
+              <kbd id="search-shortcut-mod"></kbd>
+              <kbd>K</kbd>
+            </div>
             <button class="search-clear hidden" id="search-clear" aria-label="Clear">
               <svg width="16" height="16" viewBox="0 0 16 16"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
             </button>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -556,6 +556,28 @@ html, body {
 .floating-search:hover .floating-search-text {
   color: var(--text-primary);
 }
+.floating-search-keys {
+  position: absolute;
+  right: 12px;
+  display: flex;
+  gap: 3px;
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+}
+.floating-search-keys kbd {
+  font-size: 11px;
+  font-family: inherit;
+  color: var(--text-subdued);
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 4px;
+  padding: 2px 6px;
+  line-height: 1.2;
+}
+.floating-search:hover .floating-search-keys {
+  opacity: 1;
+}
 .floating-search.hidden {
   display: none;
 }
@@ -797,7 +819,7 @@ html, body {
 }
 #search-input {
   width: 100%;
-  padding: 12px 42px 12px 44px;
+  padding: 12px 90px 12px 44px;
   border: none;
   border-radius: var(--radius-lg);
   background: rgba(255, 255, 255, 0.05);
@@ -809,6 +831,27 @@ html, body {
   transition: background var(--transition), border-color var(--transition), box-shadow var(--transition);
 }
 #search-input::placeholder { color: var(--text-subdued); }
+.search-shortcut-hint {
+  position: absolute;
+  right: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  gap: 3px;
+  pointer-events: none;
+  transition: opacity 0.15s;
+}
+.search-shortcut-hint kbd {
+  font-size: 11px;
+  font-family: inherit;
+  color: var(--text-subdued);
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 4px;
+  padding: 2px 6px;
+  line-height: 1.2;
+}
+.search-shortcut-hint.hidden { display: none; }
 #search-input:focus {
   background: rgba(255, 255, 255, 0.08);
   border-color: var(--accent-border);
@@ -851,7 +894,7 @@ html, body {
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   box-shadow: 0 8px 24px rgba(0,0,0,0.4);
   z-index: 1001;
-  padding: 6px 0;
+  padding: 6px 0 2px;
   animation: menuEnter 0.15s ease;
   transition: border-color var(--transition), box-shadow var(--transition);
 }
@@ -861,6 +904,32 @@ html, body {
   box-shadow: 0 0 0 3px var(--accent-dim), 0 8px 24px rgba(0,0,0,0.4);
 }
 .search-suggestions.hidden { display: none; }
+
+.suggestions-hint-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 7px 12px 5px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  margin-top: 4px;
+}
+.suggestions-hint {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-subdued);
+}
+.suggestions-hint kbd {
+  font-size: 10px;
+  font-family: inherit;
+  color: var(--text-subdued);
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 3px;
+  padding: 1px 5px;
+  line-height: 1.3;
+}
 
 .search-suggestion-item {
   display: flex;


### PR DESCRIPTION
### Summary

  Added Ctrl+K (Cmd+K on Mac) keyboard shortcut to instantly open and focus the search bar, inspired by Spotify's search UX. The shortcut clears previous search text for a fresh start.

###   What's New

  - Keyboard shortcut: Press Ctrl+K (Cmd+K on Mac) to open search bar anywhere in the app
  - Visual discovery: Floating search pill displays "Ctrl K" / "⌘ K" badges on hover
  - Input hints: Search input shows keyboard shortcuts when empty, hides when typing
  - Navigation guide: Suggestions dropdown footer displays "↑↓ Navigate" and "Enter Search" hints
  - OS detection: Automatically shows ⌘ symbol on Mac, Ctrl on Windows/Linux



https://github.com/user-attachments/assets/dab341d4-01f3-461e-83cb-a6828740501d



