### PR TITLE
Radio enhancements: albums, videos, artists & smart skip

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -4996,10 +4996,7 @@
 
     positionContextMenu(menu);
 
-    const track = makeTrackFromVideo(video);
-
     menu.addEventListener('click', async (ev) => {
-    menu.addEventListener('click', (ev) => {
       const item = ev.target.closest('[data-action]');
       if (!item) return;
       const action = item.dataset.action;


### PR DESCRIPTION
  ## Summary
  - Start Radio no longer restarts playback when the seed track is already playing — replaces the queue silently instead
  - Added "Start Radio" option to album and video context menus
  - New artist context menu with "Start Radio" (search results, similar artists, top artists)

  ## Test plan
  - [x] Right-click a track that's currently playing → Start Radio → verify song doesn't restart
  - [x] Right-click a track that's NOT playing → Start Radio → verify it plays from the beginning
  - [x] Right-click an album → Start Radio → verify radio starts from first track
  - [x] Right-click a video → Start Radio → verify radio starts
  - [x] Right-click an artist in search → verify context menu appears with Start Radio
  - [x] Right-click a similar artist → verify context menu appears with Start Radio
  - [x] Right-click a top artist in explore → verify context menu appears with Start Radio
  - [ ] Test artist with no top songs → verify "Could not start radio" toast