### PR TITLE
Keep Now Playing fixed while scrolling queue and add scroll-to-top bu…

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -2355,6 +2355,24 @@
   const queuePanel = $('#queue-panel');
   let _queueActiveTab = 'queue';
 
+  // Scroll-to-top buttons
+  const queueUpNext = $('#queue-up-next');
+  const historyList = $('#history-list');
+
+  $('#queue-scroll-top').addEventListener('click', () => {
+    queueUpNext.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+  $('#history-scroll-top').addEventListener('click', () => {
+    historyList.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+
+  queueUpNext.addEventListener('scroll', () => {
+    $('#queue-scroll-top').classList.toggle('visible', queueUpNext.scrollTop > 100);
+  });
+  historyList.addEventListener('scroll', () => {
+    $('#history-scroll-top').classList.toggle('visible', historyList.scrollTop > 100);
+  });
+
   $('#btn-queue').addEventListener('click', () => {
     queuePanel.classList.toggle('hidden');
     queuePanel.classList.toggle('visible');
@@ -2567,7 +2585,7 @@
       }
 
       // Auto-scroll when dragging near edges
-      const rect = queuePanel.getBoundingClientRect();
+      const rect = container.getBoundingClientRect();
       const distTop = e.clientY - rect.top;
       const distBottom = rect.bottom - e.clientY;
 
@@ -2586,7 +2604,7 @@
   function startDragScroll() {
     if (_dragScrollRAF) return;
     const tick = () => {
-      queuePanel.scrollTop += _dragScrollSpeed;
+      $('#queue-up-next').scrollTop += _dragScrollSpeed;
       _dragScrollRAF = requestAnimationFrame(tick);
     };
     _dragScrollRAF = requestAnimationFrame(tick);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -697,12 +697,15 @@
         <h4>Now Playing</h4>
         <div id="queue-now-playing"></div>
       </div>
-      <div class="queue-section">
+      <div class="queue-section queue-upnext-section">
         <div class="queue-section-header">
           <h4>Up Next</h4>
           <button class="queue-clear-btn" id="btn-clear-queue">Clear</button>
         </div>
         <div id="queue-up-next"></div>
+        <button class="queue-scroll-top" id="queue-scroll-top" title="Back to top">
+          <svg width="14" height="14" viewBox="0 0 16 16"><path d="M3 10l5-5 5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+        </button>
       </div>
     </div>
     <!-- History View -->
@@ -711,12 +714,15 @@
         <h4>Now Playing</h4>
         <div id="history-now-playing"></div>
       </div>
-      <div class="queue-section">
+      <div class="queue-section queue-upnext-section">
         <div class="queue-section-header">
           <h4>Recently Played</h4>
           <button class="queue-clear-btn" id="btn-clear-history">Clear</button>
         </div>
         <div id="history-list"></div>
+        <button class="queue-scroll-top" id="history-scroll-top" title="Back to top">
+          <svg width="14" height="14" viewBox="0 0 16 16"><path d="M3 10l5-5 5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+        </button>
       </div>
     </div>
   </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1514,7 +1514,9 @@ html, body {
   background: var(--bg-surface);
   border-left: 1px solid rgba(255, 255, 255, 0.05);
   z-index: 90;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   padding: 20px;
   transform: translateX(100%);
   transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
@@ -1575,6 +1577,60 @@ html, body {
   letter-spacing: 1.5px;
   font-weight: 600;
   margin-bottom: 8px;
+}
+.queue-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+}
+.queue-view > .queue-section:first-child {
+  flex-shrink: 0;
+}
+.queue-upnext-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+  margin-bottom: 0;
+}
+.queue-upnext-section .queue-section-header {
+  flex-shrink: 0;
+}
+#queue-up-next,
+#history-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.queue-scroll-top {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, background var(--transition);
+  z-index: 5;
+}
+.queue-scroll-top.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.queue-scroll-top:hover {
+  background: var(--bg-highlight);
 }
 
 .queue-item {


### PR DESCRIPTION
  ## Summary                                                                                                            
  - Pin "Now Playing" section at the top of the queue panel — only "Up Next" / "History" scrolls                        
  - Add floating scroll-to-top buttons (appear after 100px scroll) with smooth scroll animation                         
  - Fix drag-reorder auto-scroll to use the correct scrollable container instead of the panel wrapper

  ## Changes
  - **HTML**: Added `#queue-scroll-top` and `#history-scroll-top` buttons with chevron SVG icons
  - **CSS**: Restructured queue panel as flex column — first section fixed, scrollable section fills remaining space.
  Styled circular floating buttons with fade-in transition
  - **JS**: Scroll event listeners toggle button visibility, click handlers smooth-scroll to top, fixed
  `getBoundingClientRect()` and `scrollTop` references for drag-scroll

https://github.com/user-attachments/assets/5e8723ac-5436-4a80-af10-e55550a709bc

