### PR TITLE
UX polish bundle: sidebar scroll, EQ bars, speaker icon, thumbnail overlay, library context menu, time remaining

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -420,6 +420,7 @@ html, body {
 .playlist-list {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -441,6 +442,7 @@ html, body {
 .playlist-item.active { background: rgba(255, 255, 255, 0.08); }
 
 .playlist-cover {
+  position: relative;
   width: 48px;
   height: 48px;
   border-radius: 6px;
@@ -457,6 +459,22 @@ html, body {
   height: 100%;
   object-fit: cover;
 }
+.playlist-cover-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+  border-radius: 6px;
+  color: #fff;
+  cursor: pointer;
+  z-index: 1;
+}
+.playlist-cover-overlay svg { width: 20px; height: 20px; fill: #fff; }
+.playlist-item:hover .playlist-cover-overlay { opacity: 1; }
 
 /* 2x2 grid for playlist covers */
 .playlist-cover-grid {
@@ -484,6 +502,7 @@ html, body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-width: 0;
 }
 .playlist-name {
   font-size: 14px;
@@ -1045,8 +1064,10 @@ html, body {
   justify-content: center;
   color: #fff;
 }
-.track-row.playing .track-num-text { display: none; }
-.track-row.playing .track-eq { display: flex; justify-content: center; }
+.track-row.playing .track-num-text { display: inline; }
+.track-row.playing .track-eq { display: none; }
+body.audio-playing .track-row.playing .track-num-text { display: none; }
+body.audio-playing .track-row.playing .track-eq { display: flex; justify-content: center; }
 .track-row:hover .track-eq { display: none !important; }
 
 .track-main {
@@ -1388,6 +1409,7 @@ html, body {
   text-align: center;
   font-variant-numeric: tabular-nums;
 }
+#time-total, #max-np-time-total { cursor: pointer; user-select: none; }
 
 .progress-bar {
   flex: 1;


### PR DESCRIPTION
  ## Summary
  - Fix sidebar horizontal scroll overflow and text ellipsis
  - EQ bars now hide on pause and reappear on play (`body.audio-playing`)
  - Speaker icon in sidebar hides when playback is paused
  - Play/pause overlay on sidebar playlist thumbnails (hover to reveal)
  - Right-click context menu on library cards (same as sidebar)
  - Click time total to toggle between duration and remaining time
  - Sync library view on playlist create/rename/delete/cover changes

https://github.com/user-attachments/assets/b4ee7fa3-a0d9-467e-ba55-5e4564f6bb97


https://github.com/user-attachments/assets/0d32f946-1f77-47fd-83ad-b589d61d70f9



